### PR TITLE
Add Debian support

### DIFF
--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -1,6 +1,6 @@
 class clam::package {
     case $operatingsystem {
-        ubuntu: {
+        debian, ubuntu: {
             include clam::package::debian
         }
         centos: {


### PR DESCRIPTION
Tested for Debian on 6 and 7, both i386 and amd64, works fine with the same package info as Ubuntu.
